### PR TITLE
AWS CLI v2のインストールコマンドを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-
   
 # aws cli v2 のインストール
 # https://docs.aws.amazon.com/ja_jp/cli/latest/userguide/install-cliv2-linux.html
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN sh -c 'curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"'
 RUN unzip awscliv2.zip
 RUN sudo ./aws/install
 


### PR DESCRIPTION
  ## 説明
Dockerfile内のAWS CLI v2のインストールコマンドを修正しました。

 ## 変更内容
AWS CLI v2のインストールコマンドを以下のように変更しました
```
RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"   
```

から

```
RUN sh -c 'curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"' 
``` 
へ変更しました。

## 目的
AWS CLI v2のダウンロードリンクをシステムのアーキテクチャに応じて動的に変更しました。
これにより、arm64系（Raspberry Piなど）で動作するようになりました。

## テスト
下記環境で動作確認済み
- arm64系 Raspberry Pi 5(Ubuntu 24.04.1)
- x86_64系 PC(Ubuntu 24.04.1)
